### PR TITLE
Forbid some outgoing requests, based on filters

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,9 @@
     "parserOptions": {
         "sourceType": "module"
     },
+    "parser": "babel-eslint",
     "rules": {
+        "strict": 0,
         "indent": [
             "error",
             4

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ npm-debug.log
 .DS_Store
 client.config.js
 agave-debug.js
+.idea

--- a/config.js
+++ b/config.js
@@ -33,6 +33,7 @@ let config = {
             'pass':    process.env.CRN_SERVER_MAIL_PASS
         }
     },
+    forbidRequests: process.env.FORBID_REQUESTS !== 'false',
     forbiddenRequestUrls: [
         /^https:\/\/api\.tacc\.utexas\.edu.*/
     ]

--- a/config.js
+++ b/config.js
@@ -34,7 +34,7 @@ let config = {
         }
     },
     forbiddenRequestUrls: [
-        /agave/
+        /^https:\/\/api\.tacc\.utexas\.edu.*/
     ]
 };
 

--- a/config.js
+++ b/config.js
@@ -32,7 +32,10 @@ let config = {
             'user':    process.env.CRN_SERVER_MAIL_USER,
             'pass':    process.env.CRN_SERVER_MAIL_PASS
         }
-    }
+    },
+    forbiddenRequestUrls: [
+        /agave/
+    ]
 };
 
 export default config;

--- a/handlers/jobs.js
+++ b/handlers/jobs.js
@@ -2,38 +2,38 @@
 
 // dependencies ------------------------------------------------------------
 
-import agave         from '../libs/agave';
-import sanitize      from '../libs/sanitize';
-import scitran       from '../libs/scitran';
-import mongo         from '../libs/mongo';
-import async         from 'async';
-import crypto        from 'crypto';
-import archiver      from 'archiver';
-import notifications from '../libs/notifications';
-import {ObjectID}    from 'mongodb';
-
-let c = mongo.collections;
-
-// models ------------------------------------------------------------------
-
-let models = {
-    job: {
-        appId:             'string, required',
-        appLabel:          'string, required',
-        appVersion:        'string, required',
-        datasetId:         'string, required',
-        datasetLabel:      'stirng, required',
-        executionSystem:   'String, required',
-        parameters:        'object, required',
-        snapshotId:        'string, required',
-        userId:            'string, required',
-        batchQueue:        'string, required',
-        memoryPerNode:     'number, required',
-        nodeCount:         'number, required',
-        processorsPerNode: 'number, required',
-        input:             'string'
-    }
-};
+// import agave         from '../libs/agave';
+// import sanitize      from '../libs/sanitize';
+// import scitran       from '../libs/scitran';
+// import mongo         from '../libs/mongo';
+// import async         from 'async';
+// import crypto        from 'crypto';
+// import archiver      from 'archiver';
+// import notifications from '../libs/notifications';
+// import {ObjectID}    from 'mongodb';
+//
+// let c = mongo.collections;
+//
+// // models ------------------------------------------------------------------
+//
+// let models = {
+//     job: {
+//         appId:             'string, required',
+//         appLabel:          'string, required',
+//         appVersion:        'string, required',
+//         datasetId:         'string, required',
+//         datasetLabel:      'stirng, required',
+//         executionSystem:   'String, required',
+//         parameters:        'object, required',
+//         snapshotId:        'string, required',
+//         userId:            'string, required',
+//         batchQueue:        'string, required',
+//         memoryPerNode:     'number, required',
+//         nodeCount:         'number, required',
+//         processorsPerNode: 'number, required',
+//         input:             'string'
+//     }
+// };
 
 // handlers ----------------------------------------------------------------
 
@@ -48,409 +48,420 @@ let handlers = {
      * GET Apps
      */
     getApps(req, res, next) {
-        agave.api.listApps((err, resp) => {
-            if (err) {return next(err);}
-            let apps = [];
-            async.each(resp.body.result, (app, cb) => {
-                agave.api.getApp(app.id, (err, resp2) => {
-                    if (resp2.body && resp2.body.result) {
-                        apps.push(resp2.body.result);
-                    }
-                    cb();
-                });
-            }, () => {
-                res.send(apps);
-            });
-        });
+        next();
+        // agave.api.listApps((err, resp) => {
+        //     if (err) {return next(err);}
+        //     let apps = [];
+        //     async.each(resp.body.result, (app, cb) => {
+        //         agave.api.getApp(app.id, (err, resp2) => {
+        //             if (resp2.body && resp2.body.result) {
+        //                 apps.push(resp2.body.result);
+        //             }
+        //             cb();
+        //         });
+        //     }, () => {
+        //         res.send(apps);
+        //     });
+        // });
     },
 
     /**
      * POST Job
      */
     postJob(req, res, next) {
-        sanitize.req(req, models.job, (err, job) => {
-            if (err) {return next(err);}
-            scitran.downloadSymlinkDataset(job.snapshotId, (err, hash) => {
-                job.datasetHash = hash;
-                job.parametersHash = crypto.createHash('md5').update(JSON.stringify(job.parameters)).digest('hex');
-
-                c.crn.jobs.findOne({
-                    appId:          job.appId,
-                    datasetHash:    job.datasetHash,
-                    parametersHash: job.parametersHash,
-                    snapshotId:     job.snapshotId
-                }, {}, (err, existingJob) => {
-                    if (err){return next(err);}
-                    if (existingJob) {
-                        // allow retrying failed jobs
-                        if (existingJob.agave && existingJob.agave.status === 'FAILED') {
-                            handlers.retry({params: {jobId: existingJob.jobId}}, res, next);
-                            return;
-                        }
-                        let error = new Error('A job with the same dataset and parameters has already been run.');
-                        error.http_code = 409;
-                        return next(error);
-                    }
-
-                    agave.submitJob(job, (err, resp) => {
-                        if (err) {return next(err);}
-                        res.send(resp);
-                    });
-                });
-            }, {snapshot: true});
-        });
+        next();
+        // sanitize.req(req, models.job, (err, job) => {
+        //     if (err) {return next(err);}
+        //     scitran.downloadSymlinkDataset(job.snapshotId, (err, hash) => {
+        //         job.datasetHash = hash;
+        //         job.parametersHash = crypto.createHash('md5').update(JSON.stringify(job.parameters)).digest('hex');
+        //
+        //         c.crn.jobs.findOne({
+        //             appId:          job.appId,
+        //             datasetHash:    job.datasetHash,
+        //             parametersHash: job.parametersHash,
+        //             snapshotId:     job.snapshotId
+        //         }, {}, (err, existingJob) => {
+        //             if (err){return next(err);}
+        //             if (existingJob) {
+        //                 // allow retrying failed jobs
+        //                 if (existingJob.agave && existingJob.agave.status === 'FAILED') {
+        //                     handlers.retry({params: {jobId: existingJob.jobId}}, res, next);
+        //                     return;
+        //                 }
+        //                 let error = new Error('A job with the same dataset and parameters has already been run.');
+        //                 error.http_code = 409;
+        //                 return next(error);
+        //             }
+        //
+        //             res.send(null);
+        //
+        //             // agave.submitJob(job, (err, resp) => {
+        //             //     if (err) {return next(err);}
+        //             //     res.send(resp);
+        //             // });
+        //         });
+        //     }, {snapshot: true});
+        // });
     },
 
     /**
      * Retry
      */
     retry (req, res, next) {
-        let jobId = req.params.jobId;
-
-        // find job
-        c.crn.jobs.findOne({jobId}, {}, (err, job) => {
-            if (err){return next(err);}
-            if (!job) {
-                let error = new Error('Could not find job.');
-                error.http_code = 404;
-                return next(error);
-            }
-            if (job.agave.status && job.agave.status === 'FINISHED') {
-                let error = new Error('A job with the same dataset and parameters has already successfully finished.');
-                error.http_code = 409;
-                return next(error);
-            }
-            if (job.agave.status && job.agave.status !== 'FAILED') {
-                let error = new Error('A job with the same dataset and parameters is currently running.');
-                error.http_code = 409;
-                return next(error);
-            }
-
-            // re-submit job with old job data
-            agave.submitJob(job, (err, resp) => {
-                if (err) {
-                    return next(err);
-                } else {
-                    // delete old job
-                    c.crn.jobs.removeOne({jobId}, {}, (err) => {
-                        if (err) {return next(err);}
-                        res.send(resp);
-                    });
-                }
-            });
-        });
+        next();
+        // let jobId = req.params.jobId;
+        //
+        // // find job
+        // c.crn.jobs.findOne({jobId}, {}, (err, job) => {
+        //     if (err){return next(err);}
+        //     if (!job) {
+        //         let error = new Error('Could not find job.');
+        //         error.http_code = 404;
+        //         return next(error);
+        //     }
+        //     if (job.agave.status && job.agave.status === 'FINISHED') {
+        //         let error = new Error('A job with the same dataset and parameters has already successfully finished.');
+        //         error.http_code = 409;
+        //         return next(error);
+        //     }
+        //     if (job.agave.status && job.agave.status !== 'FAILED') {
+        //         let error = new Error('A job with the same dataset and parameters is currently running.');
+        //         error.http_code = 409;
+        //         return next(error);
+        //     }
+        //
+        //     // re-submit job with old job data
+        //     agave.submitJob(job, (err, resp) => {
+        //         if (err) {
+        //             return next(err);
+        //         } else {
+        //             // delete old job
+        //             c.crn.jobs.removeOne({jobId}, {}, (err) => {
+        //                 if (err) {return next(err);}
+        //                 res.send(resp);
+        //             });
+        //         }
+        //     });
+        // });
     },
 
     /**
      *  GET Dataset Jobs
      */
     getDatasetJobs(req, res, next) {
-        let snapshot   = req.query.hasOwnProperty('snapshot') && req.query.snapshot == 'true';
-        let datasetId  = req.params.datasetId;
-        let user       = req.user;
-        let hasAccess  = req.hasAccess;
-
-        let query = snapshot ? {snapshotId: datasetId} : {datasetId};
-        c.crn.jobs.find(query).toArray((err, jobs) => {
-            if (err) {return next(err);}
-            if (snapshot) {
-                if (!hasAccess) {
-                    let error = new Error('You do not have access to view jobs for this dataset.');
-                    error.http_code = 403;
-                    return next(error);
-                }
-                // remove user ID on public requests
-                if (!user) {
-                    for (let job of jobs) {delete job.userId;}
-                }
-                res.send(jobs);
-            } else {
-                scitran.getProjectSnapshots(datasetId, (err, resp) => {
-                    let snapshots = resp.body;
-                    let filteredJobs = [];
-                    for (let job of jobs) {
-                        for (let snapshot of snapshots) {
-                            if ((snapshot.public || hasAccess) && (snapshot._id === job.snapshotId)) {
-                                if (!user) {delete job.userId;}
-                                filteredJobs.push(job);
-                            }
-                        }
-                    }
-                    res.send(filteredJobs);
-                });
-            }
-        });
+        next();
+        // let snapshot   = req.query.hasOwnProperty('snapshot') && req.query.snapshot == 'true';
+        // let datasetId  = req.params.datasetId;
+        // let user       = req.user;
+        // let hasAccess  = req.hasAccess;
+        //
+        // let query = snapshot ? {snapshotId: datasetId} : {datasetId};
+        // c.crn.jobs.find(query).toArray((err, jobs) => {
+        //     if (err) {return next(err);}
+        //     if (snapshot) {
+        //         if (!hasAccess) {
+        //             let error = new Error('You do not have access to view jobs for this dataset.');
+        //             error.http_code = 403;
+        //             return next(error);
+        //         }
+        //         // remove user ID on public requests
+        //         if (!user) {
+        //             for (let job of jobs) {delete job.userId;}
+        //         }
+        //         res.send(jobs);
+        //     } else {
+        //         scitran.getProjectSnapshots(datasetId, (err, resp) => {
+        //             let snapshots = resp.body;
+        //             let filteredJobs = [];
+        //             for (let job of jobs) {
+        //                 for (let snapshot of snapshots) {
+        //                     if ((snapshot.public || hasAccess) && (snapshot._id === job.snapshotId)) {
+        //                         if (!user) {delete job.userId;}
+        //                         filteredJobs.push(job);
+        //                     }
+        //                 }
+        //             }
+        //             res.send(filteredJobs);
+        //         });
+        //     }
+        // });
     },
 
     /**
      * POST Results
      */
-    postResults(req, res) {
-        let jobId = req.params.jobId;
-        c.crn.jobs.findOne({jobId}, {}, (err, job) => {
-            if (!job || job.agave.status === 'FAILED' || job.agave.status === 'FINISHED') {
-                // occasionally result webhooks callback before the
-                // original job submission is saved or after the job
-                // is complete. in these cases do nothing.
-                res.send({});
-            } else if (req.body.status === job.agave.status) {
-                res.send(job);
-            } else if (req.body.status === 'FINISHED' || req.body.status === 'FAILED') {
-                agave.getOutputs(jobId, (results, logs) => {
-                    c.crn.jobs.updateOne({jobId}, {$set: {agave: req.body, results, logs}}, {}).then((err, result) => {
-                        if (err) {res.send(err);}
-                        else {res.send(result);}
-                        job.agave = req.body;
-                        job.results = results;
-
-                        notifications.jobComplete(job);
-                    });
-                });
-            } else {
-                c.crn.jobs.updateOne({jobId}, {$set: {agave: req.body}}, {}, (err, result) => {
-                    if (err) {res.send(err);}
-                    else {res.send(result);}
-                });
-            }
-        });
+    postResults(req, res, next) {
+        next();
+        // let jobId = req.params.jobId;
+        // c.crn.jobs.findOne({jobId}, {}, (err, job) => {
+        //     if (!job || job.agave.status === 'FAILED' || job.agave.status === 'FINISHED') {
+        //         // occasionally result webhooks callback before the
+        //         // original job submission is saved or after the job
+        //         // is complete. in these cases do nothing.
+        //         res.send({});
+        //     } else if (req.body.status === job.agave.status) {
+        //         res.send(job);
+        //     } else if (req.body.status === 'FINISHED' || req.body.status === 'FAILED') {
+        //         agave.getOutputs(jobId, (results, logs) => {
+        //             c.crn.jobs.updateOne({jobId}, {$set: {agave: req.body, results, logs}}, {}).then((err, result) => {
+        //                 if (err) {res.send(err);}
+        //                 else {res.send(result);}
+        //                 job.agave = req.body;
+        //                 job.results = results;
+        //
+        //                 notifications.jobComplete(job);
+        //             });
+        //         });
+        //     } else {
+        //         c.crn.jobs.updateOne({jobId}, {$set: {agave: req.body}}, {}, (err, result) => {
+        //             if (err) {res.send(err);}
+        //             else {res.send(result);}
+        //         });
+        //     }
+        // });
     },
 
     /**
      * GET Job
      */
-    getJob(req, res) {
-        let jobId = req.params.jobId;
-        c.crn.jobs.findOne({jobId}, {}, (err, job) => {
-            let status = job.agave.status;
-
-            // check if job is already known to be completed
-            if ((status === 'FINISHED' && job.results && job.results.length > 0) || status === 'FAILED') {
-                res.send(job);
-            } else {
-                agave.api.getJob(jobId, (err, resp) => {
-                    // check status
-                    if (resp.body.status === 'error' && resp.body.message.indexOf('No job found with job id') > -1) {
-                        job.agave.status = 'FAILED';
-                        c.crn.jobs.updateOne({jobId}, {$set: {agave: job.agave}}, {}, () => {
-                            res.send({agave: resp.body.result, snapshotId: job.snapshotId});
-                            notifications.jobComplete(job);
-                        });
-                    } else if (resp.body && resp.body.result && (resp.body.result.status === 'FINISHED' || resp.body.result.status === 'FAILED')) {
-                        job.agave = resp.body.result;
-                        agave.getOutputs(jobId, (results, logs) => {
-                            c.crn.jobs.updateOne({jobId}, {$set: {agave: resp.body.result, results, logs}}, {}, (err) => {
-                                if (err) {res.send(err);}
-                                else {res.send({agave: resp.body.result, results, logs, snapshotId: job.snapshotId});}
-                                job.agave = resp.body.result;
-                                job.results = results;
-                                job.logs = logs;
-                                if (status !== 'FINISHED') {notifications.jobComplete(job);}
-                            });
-                        });
-                    } else if (resp.body && resp.body.result && job.agave.status !== resp.body.result.status) {
-                        job.agave = resp.body.result;
-                        c.crn.jobs.updateOne({jobId}, {$set: {agave: resp.body.result}}, {}, (err) => {
-                            if (err) {res.send(err);}
-                            else {
-                                res.send({
-                                    agave:      resp.body.result,
-                                    datasetId:  job.datasetId,
-                                    snapshotId: job.snapshotId,
-                                    jobId:      jobId
-                                });
-                            }
-                        });
-                    } else {
-                        res.send({
-                            agave:      resp.body.result,
-                            datasetId:  job.datasetId,
-                            snapshotId: job.snapshotId,
-                            jobId:      jobId
-                        });
-                    }
-                });
-            }
-        });
+    getJob(req, res, next) {
+        next();
+        // let jobId = req.params.jobId;
+        // c.crn.jobs.findOne({jobId}, {}, (err, job) => {
+        //     let status = job.agave.status;
+        //
+        //     // check if job is already known to be completed
+        //     if ((status === 'FINISHED' && job.results && job.results.length > 0) || status === 'FAILED') {
+        //         res.send(job);
+        //     } else {
+        //         agave.api.getJob(jobId, (err, resp) => {
+        //             // check status
+        //             if (resp.body.status === 'error' && resp.body.message.indexOf('No job found with job id') > -1) {
+        //                 job.agave.status = 'FAILED';
+        //                 c.crn.jobs.updateOne({jobId}, {$set: {agave: job.agave}}, {}, () => {
+        //                     res.send({agave: resp.body.result, snapshotId: job.snapshotId});
+        //                     notifications.jobComplete(job);
+        //                 });
+        //             } else if (resp.body && resp.body.result && (resp.body.result.status === 'FINISHED' || resp.body.result.status === 'FAILED')) {
+        //                 job.agave = resp.body.result;
+        //                 agave.getOutputs(jobId, (results, logs) => {
+        //                     c.crn.jobs.updateOne({jobId}, {$set: {agave: resp.body.result, results, logs}}, {}, (err) => {
+        //                         if (err) {res.send(err);}
+        //                         else {res.send({agave: resp.body.result, results, logs, snapshotId: job.snapshotId});}
+        //                         job.agave = resp.body.result;
+        //                         job.results = results;
+        //                         job.logs = logs;
+        //                         if (status !== 'FINISHED') {notifications.jobComplete(job);}
+        //                     });
+        //                 });
+        //             } else if (resp.body && resp.body.result && job.agave.status !== resp.body.result.status) {
+        //                 job.agave = resp.body.result;
+        //                 c.crn.jobs.updateOne({jobId}, {$set: {agave: resp.body.result}}, {}, (err) => {
+        //                     if (err) {res.send(err);}
+        //                     else {
+        //                         res.send({
+        //                             agave:      resp.body.result,
+        //                             datasetId:  job.datasetId,
+        //                             snapshotId: job.snapshotId,
+        //                             jobId:      jobId
+        //                         });
+        //                     }
+        //                 });
+        //             } else {
+        //                 res.send({
+        //                     agave:      resp.body.result,
+        //                     datasetId:  job.datasetId,
+        //                     snapshotId: job.snapshotId,
+        //                     jobId:      jobId
+        //                 });
+        //             }
+        //         });
+        //     }
+        // });
     },
 
-    getJobs(req, res) {
-        c.crn.jobs.find().toArray((err, jobs) => {
-            if (err) {
-                res.send(err);
-                return;
-            }
-
-            // store request metadata
-            let availableApps = {};
-
-            // filter jobs by permissions
-            let filteredJobs = [];
-
-            if (req.query.public === 'true') {
-                async.each(jobs, (job, cb) => {
-                    c.scitran.project_snapshots.findOne({'_id': ObjectID(job.snapshotId)}, {}, (err, snapshot) => {
-                        if (snapshot && snapshot.public === true) {
-                            buildMetadata(job);
-                            filteredJobs.push(job);
-                            cb();
-                        } else {
-                            cb();
-                        }
-                    });
-                }, () => {
-                    res.send({availableApps: reMapMetadata(availableApps), jobs: filteredJobs});
-                });
-            } else {
-                for (let job of jobs) {
-                    if (req.user === job.userId) {
-                        buildMetadata(job);
-                        filteredJobs.push(job);
-                    }
-                }
-                res.send({availableApps: reMapMetadata(availableApps), jobs: filteredJobs});
-            }
-
-            function buildMetadata(job) {
-                if (!availableApps.hasOwnProperty(job.appLabel)) {
-                    availableApps[job.appLabel] = {versions: {}};
-                    availableApps[job.appLabel].versions[job.appVersion] = job.appId;
-                } else if (!availableApps[job.appLabel].versions.hasOwnProperty(job.appVersion)) {
-                    availableApps[job.appLabel].versions[job.appVersion] = job.appId;
-                }
-            }
-
-            function reMapMetadata(apps) {
-                let remapped = [];
-                for (let app in apps) {
-                    let tempApp = {label: app, versions: []};
-                    for (let version in apps[app].versions) {
-                        tempApp.versions.push({
-                            version,
-                            id: apps[app].versions[version]
-                        });
-                    }
-                    remapped.push(tempApp);
-                }
-                return remapped;
-            }
-        });
+    getJobs(req, res, next) {
+        next();
+        // c.crn.jobs.find().toArray((err, jobs) => {
+        //     if (err) {
+        //         res.send(err);
+        //         return;
+        //     }
+        //
+        //     // store request metadata
+        //     let availableApps = {};
+        //
+        //     // filter jobs by permissions
+        //     let filteredJobs = [];
+        //
+        //     if (req.query.public === 'true') {
+        //         async.each(jobs, (job, cb) => {
+        //             c.scitran.project_snapshots.findOne({'_id': ObjectID(job.snapshotId)}, {}, (err, snapshot) => {
+        //                 if (snapshot && snapshot.public === true) {
+        //                     buildMetadata(job);
+        //                     filteredJobs.push(job);
+        //                     cb();
+        //                 } else {
+        //                     cb();
+        //                 }
+        //             });
+        //         }, () => {
+        //             res.send({availableApps: reMapMetadata(availableApps), jobs: filteredJobs});
+        //         });
+        //     } else {
+        //         for (let job of jobs) {
+        //             if (req.user === job.userId) {
+        //                 buildMetadata(job);
+        //                 filteredJobs.push(job);
+        //             }
+        //         }
+        //         res.send({availableApps: reMapMetadata(availableApps), jobs: filteredJobs});
+        //     }
+        //
+        //     function buildMetadata(job) {
+        //         if (!availableApps.hasOwnProperty(job.appLabel)) {
+        //             availableApps[job.appLabel] = {versions: {}};
+        //             availableApps[job.appLabel].versions[job.appVersion] = job.appId;
+        //         } else if (!availableApps[job.appLabel].versions.hasOwnProperty(job.appVersion)) {
+        //             availableApps[job.appLabel].versions[job.appVersion] = job.appId;
+        //         }
+        //     }
+        //
+        //     function reMapMetadata(apps) {
+        //         let remapped = [];
+        //         for (let app in apps) {
+        //             let tempApp = {label: app, versions: []};
+        //             for (let version in apps[app].versions) {
+        //                 tempApp.versions.push({
+        //                     version,
+        //                     id: apps[app].versions[version]
+        //                 });
+        //             }
+        //             remapped.push(tempApp);
+        //         }
+        //         return remapped;
+        //     }
+        // });
     },
 
     /**
      * GET Download Ticket
      */
     getDownloadTicket(req, res, next) {
-        let jobId    = req.params.jobId,
-            filePath = req.query.filePath,
-            fileName = filePath.split('/')[filePath.split('/').length - 1];
-        c.crn.jobs.findOne({jobId}, {}, (err, job) => {
-            // check for job
-            if (err){return next(err);}
-            if (!job) {
-                let error = new Error('Could not find job.');
-                error.http_code = 404;
-                return next(error);
-            }
-
-            // form ticket
-            let ticket = {
-                type: 'download',
-                userId: req.user,
-                jobId: jobId,
-                fileName: fileName,
-                filePath: filePath,
-                created: new Date()
-            };
-
-            // Create and return ticket
-            c.crn.tickets.insertOne(ticket, (err) => {
-                if (err) {return next(err);}
-                c.crn.tickets.ensureIndex({created: 1}, {expireAfterSeconds: 60 * 60}, () => {
-                    res.send(ticket);
-                });
-            });
-        });
+        next();
+        // let jobId    = req.params.jobId,
+        //     filePath = req.query.filePath,
+        //     fileName = filePath.split('/')[filePath.split('/').length - 1];
+        // c.crn.jobs.findOne({jobId}, {}, (err, job) => {
+        //     // check for job
+        //     if (err){return next(err);}
+        //     if (!job) {
+        //         let error = new Error('Could not find job.');
+        //         error.http_code = 404;
+        //         return next(error);
+        //     }
+        //
+        //     // form ticket
+        //     let ticket = {
+        //         type: 'download',
+        //         userId: req.user,
+        //         jobId: jobId,
+        //         fileName: fileName,
+        //         filePath: filePath,
+        //         created: new Date()
+        //     };
+        //
+        //     // Create and return ticket
+        //     c.crn.tickets.insertOne(ticket, (err) => {
+        //         if (err) {return next(err);}
+        //         c.crn.tickets.ensureIndex({created: 1}, {expireAfterSeconds: 60 * 60}, () => {
+        //             res.send(ticket);
+        //         });
+        //     });
+        // });
     },
 
     /**
      * GET File
      */
-    getFile(req, res) {
-        let jobId = req.params.jobId;
-
-        const path = req.ticket.filePath;
-        if (path === 'all-results' || path === 'all-logs') {
-
-            const type = path.replace('all-', '');
-
-            // initialize archive
-            let archive = archiver('zip');
-
-            // log archiving errors
-            archive.on('error', (err) => {
-                console.log('archiving error - job: ' + jobId);
-                console.log(err);
-            });
-
-            c.crn.jobs.findOne({jobId}, {}, (err, job) => {
-                let archiveName = job.datasetLabel + '__' + job.appId + '__' + type;
-
-                // set archive name
-                res.attachment(archiveName + '.zip');
-
-                // begin streaming archive
-                archive.pipe(res);
-
-                // recurse outputs
-                getOutputs(archiveName, job[type], type, archive, () => {
-                    archive.finalize();
-                });
-            });
-
-        } else {
-            // download individual file
-            agave.api.getPathProxy('jobs/v2/' + jobId + '/outputs/media' + path, res);
-        }
-
-        // recurse through tree outputs
-        function getOutputs(archiveName, results, type, archive, callback) {
-            const baseDir = type === 'results' ? '/out/' : '/log/';
-            async.eachSeries(results, (result, cb) => {
-                let outputName = result.path.replace(baseDir, archiveName + '/');
-                if (result.type === 'file') {
-                    let path = 'jobs/v2/' + jobId + '/outputs/media' + result.path;
-                    agave.api.getPath(path, (err, res) => {
-                        let body = res.body;
-                        if (body && body.status && body.status === 'error') {
-                            // error from AGAVE
-                            console.log('Error downloading - ', path);
-                            console.log(body);
-                        } else {
-                            // stringify JSON
-                            if (typeof body === 'object' && !Buffer.isBuffer(body)) {
-                                body = JSON.stringify(body);
-                            }
-                            // stringify numbers
-                            if (typeof body === 'number') {
-                                body = body.toString();
-                            }
-                            // handle empty files
-                            if (typeof body === 'undefined') {
-                                body = '';
-                            }
-                            // append file to archive
-                            archive.append(body, {name: outputName});
-                        }
-                        cb();
-                    });
-                } else if (result.type === 'dir') {
-                    archive.append(null, {name: outputName + '/'});
-                    getOutputs(archiveName, result.children, type, archive, cb);
-                } else {
-                    cb();
-                }
-            }, callback);
-        }
+    getFile(req, res, next) {
+        next();
+        // let jobId = req.params.jobId;
+        //
+        // const path = req.ticket.filePath;
+        // if (path === 'all-results' || path === 'all-logs') {
+        //
+        //     const type = path.replace('all-', '');
+        //
+        //     // initialize archive
+        //     let archive = archiver('zip');
+        //
+        //     // log archiving errors
+        //     archive.on('error', (err) => {
+        //         console.log('archiving error - job: ' + jobId);
+        //         console.log(err);
+        //     });
+        //
+        //     c.crn.jobs.findOne({jobId}, {}, (err, job) => {
+        //         let archiveName = job.datasetLabel + '__' + job.appId + '__' + type;
+        //
+        //         // set archive name
+        //         res.attachment(archiveName + '.zip');
+        //
+        //         // begin streaming archive
+        //         archive.pipe(res);
+        //
+        //         // recurse outputs
+        //         getOutputs(archiveName, job[type], type, archive, () => {
+        //             archive.finalize();
+        //         });
+        //     });
+        //
+        // } else {
+        //     // download individual file
+        //     agave.api.getPathProxy('jobs/v2/' + jobId + '/outputs/media' + path, res);
+        // }
+        //
+        // // recurse through tree outputs
+        // function getOutputs(archiveName, results, type, archive, callback) {
+        //     const baseDir = type === 'results' ? '/out/' : '/log/';
+        //     async.eachSeries(results, (result, cb) => {
+        //         let outputName = result.path.replace(baseDir, archiveName + '/');
+        //         if (result.type === 'file') {
+        //             let path = 'jobs/v2/' + jobId + '/outputs/media' + result.path;
+        //             agave.api.getPath(path, (err, res) => {
+        //                 let body = res.body;
+        //                 if (body && body.status && body.status === 'error') {
+        //                     // error from AGAVE
+        //                     console.log('Error downloading - ', path);
+        //                     console.log(body);
+        //                 } else {
+        //                     // stringify JSON
+        //                     if (typeof body === 'object' && !Buffer.isBuffer(body)) {
+        //                         body = JSON.stringify(body);
+        //                     }
+        //                     // stringify numbers
+        //                     if (typeof body === 'number') {
+        //                         body = body.toString();
+        //                     }
+        //                     // handle empty files
+        //                     if (typeof body === 'undefined') {
+        //                         body = '';
+        //                     }
+        //                     // append file to archive
+        //                     archive.append(body, {name: outputName});
+        //                 }
+        //                 cb();
+        //             });
+        //         } else if (result.type === 'dir') {
+        //             archive.append(null, {name: outputName + '/'});
+        //             getOutputs(archiveName, result.children, type, archive, cb);
+        //         } else {
+        //             cb();
+        //         }
+        //     }, callback);
+        // }
 
     },
 
@@ -460,43 +471,44 @@ let handlers = {
      * Takes a dataset ID url parameter and deletes all jobs for that dataset.
      */
     deleteDatasetJobs(req, res, next) {
-        let datasetId = req.params.datasetId;
-
-        scitran.getProject(datasetId, (err, resp) => {
-            if (resp.statusCode == 400) {
-                let error = new Error('Bad request');
-                error.http_code = 400;
-                return next(error);
-            }
-            if (resp.statusCode == 404) {
-                let error = new Error('No dataset found');
-                error.http_code = 404;
-                return next(error);
-            }
-
-            let hasPermission;
-            if (!req.user) {
-                hasPermission = false;
-            } else {
-                for (let permission of resp.body.permissions) {
-                    if (req.user === permission._id && permission.access === 'admin') {
-                        hasPermission = true;
-                        break;
-                    }
-                }
-            }
-            if (!resp.body.public && hasPermission) {
-                c.crn.jobs.deleteMany({datasetId}, [], (err, doc) => {
-                    if (err) {return next(err);}
-                    res.send({message: doc.result.n + ' job(s) have been deleted for dataset ' + datasetId});
-                });
-            } else {
-                let message = resp.body.public ? 'You don\'t have permission to delete results from public datasets' : 'You don\'t have permission to delete jobs from this dataset.';
-                let error = new Error(message);
-                error.http_code = 403;
-                return next(error);
-            }
-        });
+        next();
+        // let datasetId = req.params.datasetId;
+        //
+        // scitran.getProject(datasetId, (err, resp) => {
+        //     if (resp.statusCode == 400) {
+        //         let error = new Error('Bad request');
+        //         error.http_code = 400;
+        //         return next(error);
+        //     }
+        //     if (resp.statusCode == 404) {
+        //         let error = new Error('No dataset found');
+        //         error.http_code = 404;
+        //         return next(error);
+        //     }
+        //
+        //     let hasPermission;
+        //     if (!req.user) {
+        //         hasPermission = false;
+        //     } else {
+        //         for (let permission of resp.body.permissions) {
+        //             if (req.user === permission._id && permission.access === 'admin') {
+        //                 hasPermission = true;
+        //                 break;
+        //             }
+        //         }
+        //     }
+        //     if (!resp.body.public && hasPermission) {
+        //         c.crn.jobs.deleteMany({datasetId}, [], (err, doc) => {
+        //             if (err) {return next(err);}
+        //             res.send({message: doc.result.n + ' job(s) have been deleted for dataset ' + datasetId});
+        //         });
+        //     } else {
+        //         let message = resp.body.public ? 'You don\'t have permission to delete results from public datasets' : 'You don\'t have permission to delete jobs from this dataset.';
+        //         let error = new Error(message);
+        //         error.http_code = 403;
+        //         return next(error);
+        //     }
+        // });
     }
 
 };

--- a/libs/agave/api.js
+++ b/libs/agave/api.js
@@ -1,6 +1,6 @@
 /*eslint no-console: ["error", { allow: ["log"] }] */
 
-import request from '../request';
+import request from '../request-async';
 import config  from '../../config';
 import client  from './client';
 

--- a/libs/agave/api.js
+++ b/libs/agave/api.js
@@ -1,6 +1,6 @@
 /*eslint no-console: ["error", { allow: ["log"] }] */
 
-import request from '../request-async';
+import request from '../request';
 import config  from '../../config';
 import client  from './client';
 

--- a/libs/agave/client.js
+++ b/libs/agave/client.js
@@ -45,28 +45,29 @@ let client = {
 
     recreate(callback) {
         console.log('Recreating AGAVE Client');
-        request.post(config.agave.url + 'clients/v2', {
-            headers: {
-                Authorization: 'Basic ' + new Buffer(config.agave.username + ':' + config.agave.password).toString('base64')
-            },
-            body: {
-                clientName:  config.agave.clientName,
-                description: config.agave.clientDescription
-            }
-        }, (err, res) => {
-            if (res.body.status == 'error') {
-                console.log('Error Creating AGAVE Client');
-                console.log(res.body.message);
-            } else {
-                // set config changes and save
-                client.config.name           = config.agave.clientName;
-                client.config.description    = config.agave.clientDescription;
-                client.config.consumerKey    = res.body.result.consumerKey;
-                client.config.consumerSecret = res.body.result.consumerSecret;
-                fs.writeFileSync('client.config.js', 'export default ' + JSON.stringify(client.config, null, 4));
-                callback();
-            }
-        });
+        callback();
+        // request.post(config.agave.url + 'clients/v2', {
+        //     headers: {
+        //         Authorization: 'Basic ' + new Buffer(config.agave.username + ':' + config.agave.password).toString('base64')
+        //     },
+        //     body: {
+        //         clientName:  config.agave.clientName,
+        //         description: config.agave.clientDescription
+        //     }
+        // }, (err, res) => {
+        //     if (res.body.status == 'error') {
+        //         console.log('Error Creating AGAVE Client');
+        //         console.log(res.body.message);
+        //     } else {
+        //         // set config changes and save
+        //         client.config.name           = config.agave.clientName;
+        //         client.config.description    = config.agave.clientDescription;
+        //         client.config.consumerKey    = res.body.result.consumerKey;
+        //         client.config.consumerSecret = res.body.result.consumerSecret;
+        //         fs.writeFileSync('client.config.js', 'export default ' + JSON.stringify(client.config, null, 4));
+        //         callback();
+        //     }
+        // });
     }
 };
 

--- a/libs/agave/client.js
+++ b/libs/agave/client.js
@@ -1,6 +1,6 @@
 /*eslint no-console: ["error", { allow: ["log"] }] */
 
-import request from '../request';
+// import request from '../request';
 import fs     from 'fs';
 import config from '../../config';
 

--- a/libs/agave/index.js
+++ b/libs/agave/index.js
@@ -1,168 +1,175 @@
-import config from '../../config';
-import api    from './api';
-import mongo  from '../../libs/mongo';
-import async  from 'async';
-
-let c = mongo.collections;
+// import config from '../../config';
+// import api    from './api';
+// import mongo  from '../../libs/mongo';
+// import async  from 'async';
+//
+// let c = mongo.collections;
 
 export default {
-
-    /**
-     * API
-     *
-     * Standard AGAVE API Interactions
-     */
-    api: api,
-
-    // compound API interactions ------------------------------------------------
-
-    /**
-     * Get Outputs
-     *
-     * Takes a Job ID and calls back with an
-     * array of of results/outputs.
-     */
-    getOutputs (jobId, callback) {
-        this.getLogs(jobId, (logs) => {
-            this.getResults(jobId, (results) => {
-                callback(results, logs);
-            });
-        });
-    },
-
-    /**
-     * Get Logs
-     */
-    getLogs(jobId, callback) {
-        let logs = [];
-        api.getJobLogs(jobId, (err, res) => {
-            // get main logs files
-            if (res.body.result) {
-                async.each(res.body.result, (file, cb) => {
-                    if (file.type === 'file') {
-                        logs.push(file);
-                    }
-                    cb();
-                }, () => {
-                    callback(logs);
-                });
-            } else {
-                callback(logs);
-            }
-        });
-    },
-
-    /**
-     * Get Results
-     */
-    getResults (jobId, callback) {
-        getDir(jobId, '/out', (results) => {
-            results = results.length > 0 ? results : null;
-            callback(results);
-        });
-
-        function getDir(jobId, dirPath, callback) {
-            let results = [];
-            api.getPath('jobs/v2/' + jobId + '/outputs/listings' + dirPath, (err, res) => {
-                if (res.body.result) {
-                    async.each(res.body.result, (result, cb) => {
-                        if (result.type === 'file') {
-                            results.push(result);
-                            cb();
-                        } else if (result.type === 'dir') {
-                            getDir(jobId, result.path, (subResults) => {
-                                result.children = subResults;
-                                results.push(result);
-                                cb();
-                            });
-                        }
-                    }, () => {
-                        callback(results);
-                    });
-                } else {
-                    callback(results);
-                }
-            });
-        }
-    },
-
-    /**
-     * Submit Job
-     *
-     * Takes a job definition and callsback
-     * with job submission results.
-     */
-    submitJob (job, callback) {
-        let attempts = job.attempts ? job.attempts + 1: 1;
-
-        // form job body
-        let body = {
-            name:              'crn-automated-job',
-            appId:             job.appId,
-            batchQueue:        job.batchQueue,
-            executionSystem:   job.executionSystem,
-            memoryPerNode:     job.memoryPerNode,
-            nodeCount:         job.nodeCount,
-            processorsPerNode: job.processorsPerNode,
-            archive:           true,
-            archiveSystem:     'openfmri-archive',
-            archivePath:       null,
-            inputs: {},
-            parameters: job.parameters ? job.parameters : {},
-            notifications: [
-                {
-                    url:        config.url + config.apiPrefix +  'jobs/${JOB_ID}/results',
-                    event:      '*',
-                    persistent: true
-                }
-            ]
-        };
-
-        // set input
-        let inputKey = job.input ? job.input : 'bidsFolder';
-        body.inputs[inputKey] = config.agave.storage + job.datasetHash;
-
-        // submit job
-        api.createJob(body, (err, resp) => {
-
-            // handle submission errors
-            if (resp.body.status == 'error') {
-                let error = new Error(resp.body.message);
-                error.http_code = 400;
-                return callback(error, null);
-            }
-            if (resp.statusCode !== 200 && resp.statusCode !== 201) {
-                let error = new Error(resp.body ? resp.body : 'AGAVE was unable to process this job submission.');
-                error.http_code = resp.statusCode ? resp.statusCode : 503;
-                return callback(error, null);
-            }
-
-            // store job
-            c.crn.jobs.insertOne({
-                jobId:             resp.body.result.id,
-                agave:             resp.body.result,
-
-                appId:             body.appId,
-                parameters:        body.parameters,
-                memoryPerNode:     body.memoryPerNode,
-                nodeCount:         body.nodeCount,
-                processorsPerNode: body.processorsPerNode,
-                batchQueue:        body.batchQueue,
-
-                appLabel:          job.appLabel,
-                appVersion:        job.appVersion,
-                datasetHash:       job.datasetHash,
-                datasetId:         job.datasetId,
-                datasetLabel:      job.datasetLabel,
-                userId:            job.userId,
-                parametersHash:    job.parametersHash,
-                snapshotId:        job.snapshotId,
-
-                attempts:          attempts
-            }, () => {
-                callback(null, resp.body);
-            });
-        });
-    }
-
+    getOutputs: () => true,
+    getLogs: () => true,
+    getResults: () => true,
+    submitJob: () => true
 };
+
+// export default {
+//
+//     /**
+//      * API
+//      *
+//      * Standard AGAVE API Interactions
+//      */
+//     api: api,
+//
+//     // compound API interactions ------------------------------------------------
+//
+//     /**
+//      * Get Outputs
+//      *
+//      * Takes a Job ID and calls back with an
+//      * array of of results/outputs.
+//      */
+//     getOutputs (jobId, callback) {
+//         this.getLogs(jobId, (logs) => {
+//             this.getResults(jobId, (results) => {
+//                 callback(results, logs);
+//             });
+//         });
+//     },
+//
+//     /**
+//      * Get Logs
+//      */
+//     getLogs(jobId, callback) {
+//         let logs = [];
+//         api.getJobLogs(jobId, (err, res) => {
+//             // get main logs files
+//             if (res.body.result) {
+//                 async.each(res.body.result, (file, cb) => {
+//                     if (file.type === 'file') {
+//                         logs.push(file);
+//                     }
+//                     cb();
+//                 }, () => {
+//                     callback(logs);
+//                 });
+//             } else {
+//                 callback(logs);
+//             }
+//         });
+//     },
+//
+//     /**
+//      * Get Results
+//      */
+//     getResults (jobId, callback) {
+//         getDir(jobId, '/out', (results) => {
+//             results = results.length > 0 ? results : null;
+//             callback(results);
+//         });
+//
+//         function getDir(jobId, dirPath, callback) {
+//             let results = [];
+//             api.getPath('jobs/v2/' + jobId + '/outputs/listings' + dirPath, (err, res) => {
+//                 if (res.body.result) {
+//                     async.each(res.body.result, (result, cb) => {
+//                         if (result.type === 'file') {
+//                             results.push(result);
+//                             cb();
+//                         } else if (result.type === 'dir') {
+//                             getDir(jobId, result.path, (subResults) => {
+//                                 result.children = subResults;
+//                                 results.push(result);
+//                                 cb();
+//                             });
+//                         }
+//                     }, () => {
+//                         callback(results);
+//                     });
+//                 } else {
+//                     callback(results);
+//                 }
+//             });
+//         }
+//     },
+//
+//     /**
+//      * Submit Job
+//      *
+//      * Takes a job definition and callsback
+//      * with job submission results.
+//      */
+//     submitJob (job, callback) {
+//         let attempts = job.attempts ? job.attempts + 1: 1;
+//
+//         // form job body
+//         let body = {
+//             name:              'crn-automated-job',
+//             appId:             job.appId,
+//             batchQueue:        job.batchQueue,
+//             executionSystem:   job.executionSystem,
+//             memoryPerNode:     job.memoryPerNode,
+//             nodeCount:         job.nodeCount,
+//             processorsPerNode: job.processorsPerNode,
+//             archive:           true,
+//             archiveSystem:     'openfmri-archive',
+//             archivePath:       null,
+//             inputs: {},
+//             parameters: job.parameters ? job.parameters : {},
+//             notifications: [
+//                 {
+//                     url:        config.url + config.apiPrefix +  'jobs/${JOB_ID}/results',
+//                     event:      '*',
+//                     persistent: true
+//                 }
+//             ]
+//         };
+//
+//         // set input
+//         let inputKey = job.input ? job.input : 'bidsFolder';
+//         body.inputs[inputKey] = config.agave.storage + job.datasetHash;
+//
+//         // submit job
+//         api.createJob(body, (err, resp) => {
+//
+//             // handle submission errors
+//             if (resp.body.status == 'error') {
+//                 let error = new Error(resp.body.message);
+//                 error.http_code = 400;
+//                 return callback(error, null);
+//             }
+//             if (resp.statusCode !== 200 && resp.statusCode !== 201) {
+//                 let error = new Error(resp.body ? resp.body : 'AGAVE was unable to process this job submission.');
+//                 error.http_code = resp.statusCode ? resp.statusCode : 503;
+//                 return callback(error, null);
+//             }
+//
+//             // store job
+//             c.crn.jobs.insertOne({
+//                 jobId:             resp.body.result.id,
+//                 agave:             resp.body.result,
+//
+//                 appId:             body.appId,
+//                 parameters:        body.parameters,
+//                 memoryPerNode:     body.memoryPerNode,
+//                 nodeCount:         body.nodeCount,
+//                 processorsPerNode: body.processorsPerNode,
+//                 batchQueue:        body.batchQueue,
+//
+//                 appLabel:          job.appLabel,
+//                 appVersion:        job.appVersion,
+//                 datasetHash:       job.datasetHash,
+//                 datasetId:         job.datasetId,
+//                 datasetLabel:      job.datasetLabel,
+//                 userId:            job.userId,
+//                 parametersHash:    job.parametersHash,
+//                 snapshotId:        job.snapshotId,
+//
+//                 attempts:          attempts
+//             }, () => {
+//                 callback(null, resp.body);
+//             });
+//         });
+//     }
+//
+// };

--- a/libs/request-async.js
+++ b/libs/request-async.js
@@ -1,0 +1,117 @@
+import config  from '../config';
+import request from 'request-promise';
+
+const { forbiddenRequestUrls } = require('../config');
+
+/**
+ * Request
+ *
+ * A wrapper of npm 'request' to allow for
+ * genericizing request and response manipulations.
+ */
+export default {
+    get: errbackWrapper(get),
+    getProxy,
+    post: errbackWrapper(post),
+    put: errbackWrapper(put),
+    del: errbackWrapper(del)
+};
+
+function get(url, options) {
+    const req = prepareRequest(url, options);
+    return getFilteredRequest(() => request.get(req), forbiddenRequestUrls);
+}
+
+/**
+ * GET PROXY
+ *
+ * Functions the same as a get request but takes a
+ * response object instead of a callback and pipes
+ * the request response to the response object.
+ */
+function getProxy(url, options, res) {
+    const req = prepareRequest(url, options);
+
+    return getFilteredRequest(url, forbiddenRequestUrls, () => {
+        request.get(req).on('response', (resp) => {
+            if (options.status) {
+                resp.statusCode = options.status;
+            }
+        }).pipe(res);
+    })();
+}
+
+function post(url, options) {
+    const req = prepareRequest(url, options);
+    return getFilteredRequest(url, forbiddenRequestUrls, () => request.post(req))();
+}
+
+function put(url, options) {
+    const req = prepareRequest(url, options);
+    return getFilteredRequest(url, forbiddenRequestUrls, () => request.put(req))();
+}
+
+function del(url, options) {
+    const req = prepareRequest(url, options);
+    return getFilteredRequest(url, forbiddenRequestUrls, () => request.del(req))();
+}
+
+/**
+ * Errback wrapper
+ *
+ * The purpose is this function is to translate
+ * async call results to errback calls
+ */
+export function errbackWrapper(actionFunc) {
+    return (url, options, callback) => {
+        try {
+            Promise.resolve(actionFunc(url, options))
+                .then(result => callback(null, result))
+                .catch(error => callback(new Error(error)));
+        } catch (error) {
+            callback(error);
+        }
+    };
+}
+
+export function getFilteredRequest(url, filters, requestFunc) {
+    if (filters.some(regexp => regexp.test(url))) {
+        return () => {
+            throw new Error('Agave calls are not permitted.');
+        };
+    } else {
+        return requestFunc;
+    }
+}
+
+export function prepareRequest(url, options) {
+    return parseOptions({
+        url: url,
+        headers: {},
+        qs: {},
+        json: {}
+    }, options);
+}
+
+/**
+ * Parse Options
+ *
+ * Normalizes request options.
+ */
+function parseOptions(req, options) {
+    if (options.query) {req.qs = options.query;}
+    if (options.body) {req.json = options.body;}
+    if (options.hasOwnProperty('encoding')) {req.encoding = options.encoding;}
+    if (req.url && req.url.indexOf(config.scitran.url) > -1 && options.droneRequest !== false) {
+        req.headers = {
+            'X-SciTran-Auth': config.scitran.secret,
+            'User-Agent': 'SciTran Drone CRN Server'
+        };
+    }
+    if (options.headers) {
+        for (let key in options.headers) {
+            req.headers[key] = options.headers[key];
+        }
+    }
+    return req;
+}

--- a/libs/request-async.js
+++ b/libs/request-async.js
@@ -1,7 +1,10 @@
 import config  from '../config';
 import request from 'request-promise';
 
-const { forbiddenRequestUrls } = require('../config');
+const {
+    forbidRequests,
+    forbiddenRequestUrls
+} = require('../config');
 
 /**
  * Request
@@ -75,7 +78,7 @@ export function errbackWrapper(actionFunc) {
 }
 
 export function getFilteredRequest(url, filters, requestFunc) {
-    if (filters.some(regexp => regexp.test(url))) {
+    if (forbidRequests && filters.some(regexp => regexp.test(url))) {
         return () => {
             throw new Error('Agave calls are not permitted.');
         };

--- a/package.json
+++ b/package.json
@@ -28,12 +28,14 @@
     "morgan": "^1.6.1",
     "nodemailer": "^2.5.0",
     "request": "^2.63.0",
+    "request-promise": "^4.2.1",
     "tar-fs": "^1.9.0",
     "underscore": "^1.8.3"
   },
   "devDependencies": {
     "babel-eslint": "^7.2.3",
     "eslint": "2.7.0",
+    "expect": "^1.20.2",
     "mocha": "3.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "underscore": "^1.8.3"
   },
   "devDependencies": {
+    "babel-eslint": "^7.2.3",
     "eslint": "2.7.0",
     "mocha": "3.0.2"
   }

--- a/server.js
+++ b/server.js
@@ -30,7 +30,7 @@ app.use(config.apiPrefix, routes);
 // error handling --------------------------------------------------
 
 app.use(function(err, req, res) {
-    res.header('Content-Type', 'application/json');
+    res.header && res.header('Content-Type', 'application/json');
     var send = {'error' : ''};
     var http_code = (typeof err.http_code === 'undefined') ? 500 : err.http_code;
     if (typeof err.message !== 'undefined' && err.message !== '') {
@@ -46,7 +46,7 @@ app.use(function(err, req, res) {
             send.error = 'there was a problem';
         }
     }
-    res.status(http_code).send(send);
+    res.status && res.status(http_code).send(send);
 });
 
 // start server ----------------------------------------------------

--- a/tests/libs/request-async.spec.js
+++ b/tests/libs/request-async.spec.js
@@ -1,0 +1,52 @@
+const expect = require('expect');
+
+import {
+    prepareRequest,
+    getFilteredRequest,
+    errbackWrapper
+} from '../../libs/request-async';
+
+describe('libs/request-async.js', () => {
+    describe('prepareRequest', () => {
+        it('should get back with the prepared request object', () => {
+            expect(prepareRequest('http://', {})).toEqual({ url: 'http://', headers: {}, qs: {}, json: {} });
+            expect(prepareRequest('http://', { query: { test: 1 } })).toEqual({ url: 'http://', headers: {}, qs: { test: 1 }, json: {} });
+        });
+    });
+
+    describe('getFilteredRequest', () => {
+        it('should reject request where the url points to Agave', async () => {
+            const actionFunc = expect.createSpy();
+            const filters = [/agave/];
+
+            expect(getFilteredRequest('http://agave', filters, actionFunc)).toThrow();
+            expect(actionFunc).toNotHaveBeenCalled();
+
+        });
+        it('should let request go when no filter match', async () => {
+            const actionFunc = expect.createSpy();
+            const filters = [/agave/];
+
+            getFilteredRequest('http://someapi', filters, actionFunc)();
+            expect(actionFunc).toHaveBeenCalled();
+        });
+    });
+
+    describe('errbackWrapper', () => {
+        it('should call errback with error if the function has thrown error', () => {
+            const errback = expect.createSpy();
+            const error = new Error();
+            errbackWrapper(() => {
+                throw error;
+            })('', '', errback);
+            expect(errback).toHaveBeenCalledWith(error);
+        });
+        it('should call errback with result', () => {
+            errbackWrapper(() => 1)('', '', (err, res) => {
+                expect(err).toBe(null);
+                expect(res).toBe(1);
+            });
+
+        });
+    });
+});


### PR DESCRIPTION
The plan was to catch those request at the lowest possible level, so the chance of introduce bugs can remain low.

Main changes:
- Introduce forbiddenRequestUrls config property
- reimplement request wrapper with promises